### PR TITLE
聖地登録関連のルーティングを設定

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,7 @@
-COMPOSE_PROJECT_NAME=seicheese-backend
+FIREBASE_PROJECT_ID=seichesse-202406
+FIREBASE_SDK_PATH=/home/user/go/src/app/configs/Seichesse Firebase Admin SDK 2024.json
+DB_USER=root
+DB_PASS=Wario-51
+DB_HOST=db
+DB_PORT=3306
+DB_NAME=SeiCheese

--- a/src/cmd/app/main.go
+++ b/src/cmd/app/main.go
@@ -50,8 +50,23 @@ func main() {
 		AuthClient: authClient,
 	}
 
+	genreHandler := &handler.GenreHandler{
+		DB: db,
+	}
+
+	seichiHandler := &handler.SeichiHandler{
+		DB: db,
+	}
+
+	contentHandler := &handler.ContentHandler{
+		DB: db,
+	}
+
 	// ルーターの登録
 	router.RegisterAuthRoutes(e, authClient, authHandler)
+	router.RegisterGenreRoutes(e, genreHandler)
+	router.RegisterSeichiRoutes(e, seichiHandler, authClient)
+	router.RegisterContentRoutes(e, contentHandler, authClient)
 
 	// サーバー起動
 	port := os.Getenv("PORT")

--- a/src/internal/middleware/router/genre_router.go
+++ b/src/internal/middleware/router/genre_router.go
@@ -1,21 +1,12 @@
 package router
 
 import (
-	"database/sql"
 	"seicheese/internal/handler"
 
 	"github.com/labstack/echo/v4"
-	"github.com/labstack/echo/v4/middleware"
 )
 
-func RegisterGenreRoutes(e *echo.Echo, db *sql.DB) {
-	// ミドルウェアの設定
-	e.Use(middleware.Logger())
-	e.Use(middleware.Recover())
-
-	// ハンドラの初期化
-	genreHandler := &handler.GenreHandler{DB: db}
-
+func RegisterGenreRoutes(e *echo.Echo, genreHandler *handler.GenreHandler) {
 	// ルーティングの設定
 	e.GET("/api/genres", genreHandler.GetGenres)
 }


### PR DESCRIPTION
今までの原因
---
認証以外のルーティングの設定がなく、認証以外の機能がDBと通信不可であった。

やったこと
===
main.goに認証以外のルーティングを設定。